### PR TITLE
Adds a priority to the CornerIcon.

### DIFF
--- a/src/MusicianModule.cs
+++ b/src/MusicianModule.cs
@@ -208,7 +208,9 @@ namespace Nekres.Musician
         private void CreateModuleIcon()
         {
             if (_moduleIcon != null) return;
-            _moduleIcon = new CornerIcon(_moduleIconTex, this.Name);
+            _moduleIcon = new CornerIcon(_moduleIconTex, this.Name) {
+                Priority = 40133923
+            };
             _moduleIcon.Click += OnModuleIconClick;
         }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Minstrel Protocol",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "namespace": "Nekres.Musician_Module",
   "package": "Musician Module.dll",
   "manifest_version": 1,


### PR DESCRIPTION
Adds a priority to the corner icon so that it generally stays in the same position at the top and allows modules like "Bag of Holding" to manage the icon.